### PR TITLE
increase buffer size of xml buffer

### DIFF
--- a/account.cpp
+++ b/account.cpp
@@ -66,7 +66,7 @@ void weechat::log_emit(void *const userdata, const xmpp_log_level_t level,
         {
             colour = weechat_color("blue");
         }
-        xmlChar *buf = (xmlChar*)malloc(strlen(xml) * 2);
+        xmlChar *buf = (xmlChar*)malloc(strlen(xml) * 3);
         if (buf == NULL) {
             weechat_printf(
                 account ? account->buffer : NULL,


### PR DESCRIPTION
would sometimes cause a malloc() unalligned tcache chunk detected
not sure if new or me specific, also not sure how large the data gets here. in the past handling awful characters I've come to *3 every plain char things that may contain oddities