### PR TITLE
Mam fixes

### DIFF
--- a/channel.cpp
+++ b/channel.cpp
@@ -1000,7 +1000,7 @@ void weechat::channel::fetch_mam(const char *id, time_t *start, time_t *end, con
     xmpp_stanza_t *x = xmpp_stanza_new(account.context);
     xmpp_stanza_set_name(x, "x");
     xmpp_stanza_set_ns(x, "jabber:x:data");
-    xmpp_stanza_set_attribute(x, "type", "result");
+    xmpp_stanza_set_attribute(x, "type", "submit");
 
     xmpp_stanza_t *field, *value, *text;
 

--- a/command.cpp
+++ b/command.cpp
@@ -767,7 +767,7 @@ int command__mam(const void *pointer, void *data,
     else
         ago->tm_mday -= MAM_DEFAULT_DAYS;
     start = mktime(ago);
-    ptr_channel->fetch_mam(NULL, &start, NULL, NULL);
+    ptr_channel->fetch_mam(xmpp_uuid_gen(ptr_account->context), &start, NULL, NULL);
 
     return WEECHAT_RC_OK;
 }


### PR DESCRIPTION
so the channel I was in ended up being misconfigured thats why I thought it didnt return any results. but I did come across two faults when looking into it not working.
- it should be `submit` instead of `result` see https://xmpp.org/extensions/xep-0313.html#filter-time
- the function crashes when calling with id NULL so avoid that

closes #19 