### PR TITLE
bump api version to fix tests

### DIFF
--- a/tests/plugin.inl
+++ b/tests/plugin.inl
@@ -62,7 +62,7 @@ std::vector<std::string> weechat_read_lines(std::vector<std::string_view> comman
 
 TEST_CASE("weechat")
 {
-    std::string plugin_api_version("20230220-01");
+    std::string plugin_api_version("20250215-01");
 
     SUBCASE("plugin api match")
     {


### PR DESCRIPTION
this was also nothing serious
besides the (rare) ocasions the mallocs fail this is now practically completely usable again

fixes #12

EDIT/thought: is it useful to have this test its going to fail every time weechat updates anything? I guess if I validate it works and the test fails because of it I can just bump it