### PR TITLE
bump version of tests

### DIFF
--- a/tests/plugin.inl
+++ b/tests/plugin.inl
@@ -62,7 +62,7 @@ std::vector<std::string> weechat_read_lines(std::vector<std::string_view> comman
 
 TEST_CASE("weechat")
 {
-    std::string plugin_api_version("20250215-01");
+    std::string plugin_api_version("20250508-01");
 
     SUBCASE("plugin api match")
     {


### PR DESCRIPTION
I updated, it still works
alteratively maybe no tests for the default make install so people dont make issues like before?

that or I push the version bumps each time I bother to update and it still works