### PR TITLE
correct completeions for account commands

### DIFF
--- a/completion.cpp
+++ b/completion.cpp
@@ -111,7 +111,7 @@ int completion__accounts_cb(const void *pointer, void *data,
 
     for (auto& ptr_account : weechat::accounts)
     {
-        weechat_hook_completion_list_add(completion, ptr_account.second.jid().data(),
+        weechat_hook_completion_list_add(completion, ptr_account.second.name.data(),
                                          0, WEECHAT_LIST_POS_SORT);
     }
 


### PR DESCRIPTION
all the account commands take name, yet the completion fills in with jid, mild annoyance fix.
could go the other way around but this makes the most sense to me to just complete the name instead of the jid