### PR TITLE
correct usage of xmlDocDumpFormatMemory

### DIFF
--- a/account.cpp
+++ b/account.cpp
@@ -66,7 +66,9 @@ void weechat::log_emit(void *const userdata, const xmpp_log_level_t level,
         {
             colour = weechat_color("blue");
         }
-        xmlChar *buf = (xmlChar*)malloc(strlen(xml) * 2);
+        xmlChar *buf = NULL;
+        int size = -1;
+        xmlDocDumpFormatMemory(doc, &buf, &size, 1);
         if (buf == NULL) {
             weechat_printf(
                 account ? account->buffer : NULL,
@@ -74,8 +76,6 @@ void weechat::log_emit(void *const userdata, const xmpp_log_level_t level,
             fclose(nullfd);
             return;
         }
-        int size = -1;
-        xmlDocDumpFormatMemory(doc, &buf, &size, 1);
         if (size <= 0) {
             weechat_printf(
                 account ? account->buffer : NULL,
@@ -99,6 +99,7 @@ void weechat::log_emit(void *const userdata, const xmpp_log_level_t level,
                 0, tags,
                 _("%s%s"), colour, lines[i]);
 
+        xmlFree(buf);
         weechat_string_free_split(lines);
         fclose(nullfd);
     }


### PR DESCRIPTION
this should correctly fix the issues of #16
what seems to have been happening was buf was an output, see https://gnome.pages.gitlab.gnome.org/libxml2/html/tree_8h.html#a3fe5e32e4a4bc711b7bc15e2870a88d8
meaning we were allocating the buffer, then letting the function internally allocate it again, and ontop of that never freeing either.

should hopefully get rid of some rare crash scenarios too